### PR TITLE
Add daily desktop users count chart

### DIFF
--- a/src/components/line-graph.js
+++ b/src/components/line-graph.js
@@ -11,7 +11,7 @@ export function LineGraph(events, {width, height, title, xKey, yKey, label, mill
         title,
         width,
         height,
-        x: {type: "utc", ticks: "month", label: null},
+        x: {type: "utc", label: null},
         y: {grid: true, inset: 10, label },
         marks: [
             Plot.lineY(events, {

--- a/src/data/checker-desktop-users-daily.json.js
+++ b/src/data/checker-desktop-users-daily.json.js
@@ -1,0 +1,8 @@
+import { jsonFetcher } from "./json-fetcher.js";
+import { getDateXDaysAgo } from "../utils/date-utils.js";
+
+const from = "2025-02-01";
+const to = getDateXDaysAgo(1);
+
+const output = await jsonFetcher(`https://stats.filspark.com/stations/desktop/daily?from=${from}&to=${to}`);  
+process.stdout.write(JSON.stringify(output));

--- a/src/index.md
+++ b/src/index.md
@@ -9,6 +9,7 @@ const CheckerParticipantsCumulative = FileAttachment("./data/checker-participant
 const CheckerParticipantsMonthlyActive = FileAttachment("./data/checker-participants-monthly-active.json").json();
 const CheckerParticipantsDailyActive = FileAttachment("./data/checker-participants-daily-active.json").json();
 const CheckerChecksDaily = FileAttachment("./data/checker-checks-daily.json").json();
+const CheckerDesktopUsersDaily = FileAttachment("./data/checker-desktop-users-daily.json").json();
 ```
 
 <div class="hero">
@@ -31,6 +32,9 @@ const CheckerChecksDaily = FileAttachment("./data/checker-checks-daily.json").js
 <div class="grid grid-cols-2" style="grid-auto-rows: 504px;">
   <div class="card">${
     resize((width) => LineGraph(CheckerParticipantsDailyActive, {width, title: "Daily Active Checker Network Accounts (unique FIL addresses)", xKey: "day", yKey: "participants", label: "Accounts" }))
+  }</div>
+  <div class="card">${
+    resize((width) => LineGraph(CheckerDesktopUsersDaily, {width, title: "Daily Active Checker Desktop Users", xKey: "day", yKey: "user_count", label: "Desktop Users" }))
   }</div>
 </div>
 


### PR DESCRIPTION
- Adds daily desktop users count chart, displaying user starting from 01.02.2025.
- Removes `ticks` property from `x` axis of line graph to enable auto-scaling.

<img width="698" alt="Screenshot 2025-02-21 at 12 56 59" src="https://github.com/user-attachments/assets/693ee4ce-7a36-4731-b7a1-91f10b9b681f" />

